### PR TITLE
Use with statement to open image to avoid memory leak

### DIFF
--- a/photohash/photohash.py
+++ b/photohash/photohash.py
@@ -8,19 +8,19 @@ def _hamming_distance(string, other_string):
 
 def average_hash(image_path, hash_size=8):
     """ Computes the average hash of the given image. """
+    with open(image_path, 'rb') as f:
+        # Open the image, resize it and convert it to black & white.
+        image = Image.open(f)
+        image = image.resize((hash_size, hash_size), Image.ANTIALIAS).convert('L')
 
-    # Open the image, resize it and convert it to black & white.
-    image = Image.open(image_path)
-    image = image.resize((hash_size, hash_size), Image.ANTIALIAS).convert('L')
+        # Get the average value of a pixel in the image.
+        pixels = list(image.getdata())
+        avg = sum(pixels) / len(pixels)
 
-    # Get the average value of a pixel in the image.
-    pixels = list(image.getdata())
-    avg = sum(pixels) / len(pixels)
-
-    # Compute the hash based on each pixels value compared to the average.
-    bits = "".join(map(lambda pixel: '1' if pixel > avg else '0', pixels))
-    hashformat = "0{hashlength}x".format(hashlength=hash_size * 2)
-    return int(bits, 2).__format__(hashformat)
+        # Compute the hash based on each pixels value compared to the average.
+        bits = "".join(map(lambda pixel: '1' if pixel > avg else '0', pixels))
+        hashformat = "0{hashlength}x".format(hashlength=hash_size * 2)
+        return int(bits, 2).__format__(hashformat)
 
 
 def distance(image_path, other_image_path):


### PR DESCRIPTION
The memory usage will keep increasing without the with statement.
In my project, call average_hash 3 million times consumes about 500MB memory.
Bellow is the test code.
The with statement solves this problem.

```python
import os
import uuid

from PIL import Image

def average_hash(image_path, hash_size=8):
    """ Computes the average hash of the given image. """

    # Open the image, resize it and convert it to black & white.
    image = Image.open(image_path)
    image = image.resize((hash_size, hash_size), Image.ANTIALIAS).convert('L')

    # Get the average value of a pixel in the image.
    pixels = list(image.getdata())
    avg = sum(pixels) / len(pixels)

    # Compute the hash based on each pixels value compared to the average.
    bits = "".join(map(lambda pixel: '1' if pixel > avg else '0', pixels))
    hashformat = "0{hashlength}x".format(hashlength=hash_size * 2)
    return int(bits, 2).__format__(hash format)

temp=open('100x100.jpg','rb').read()

def test1():
    number=1
    while True:
        print(number)
        number+=1
        temp_filename=str(uuid.uuid4())+'.jpg'
        with open(temp_filename,'wb') as f:
            f.write(temp)
        average_hash(temp_filename)
        os.remove(temp_filename)

if __name__=='__main__':
    test1()
```